### PR TITLE
Add script for pulling appstudio shared CRDs

### DIFF
--- a/hack/pull-appstudio-shared-and-regen.sh
+++ b/hack/pull-appstudio-shared-and-regen.sh
@@ -2,6 +2,6 @@
 
 # Simple script to pull the Appstudio Shared CRDs and regenerate the KCP API resources
 hackfolder="$(realpath $(dirname ${BASH_SOURCE[0]}))"
-curl -o $hackfolder/../config/crds/base/appstudio-shared-customresourcedefinitions.yaml https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/main/appstudio-shared/manifests/appstudio-shared-customresourcedefinitions.yaml
+curl -o $hackfolder/../config/crd/bases/appstudio-shared-customresourcedefinitions.yaml https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/main/appstudio-shared/manifests/appstudio-shared-customresourcedefinitions.yaml
 
 $hackfolder/generate-kcp-api.sh

--- a/hack/pull-appstudio-shared-and-regen.sh
+++ b/hack/pull-appstudio-shared-and-regen.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Simple script to pull the Appstudio Shared CRDs and regenerate the KCP API resources
+hackfolder="$(realpath $(dirname ${BASH_SOURCE[0]}))"
+curl -o $hackfolder/../config/crds/base/appstudio-shared-customresourcedefinitions.yaml https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/main/appstudio-shared/manifests/appstudio-shared-customresourcedefinitions.yaml
+
+$hackfolder/generate-kcp-api.sh


### PR DESCRIPTION
Adds a simple script under `hack/` that will pull the AppStudio-shared CRDs and regenerate the KCP API resources.